### PR TITLE
Add package.json, webpack/karma based test-runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,8 @@ language: node_js
 sudo: false
 node_js:
    - "0.12"
-env:
-   matrix:
-      # Support the laxar 1.2.0 version
-      - GRUNT_LAXAR_VERSION=~1.1.2-0
-        LAXAR_VERSION=~1.2.0
-        LAXAR_UIKIT_VERSION=~1.1.0
-        LAXAR_PATTERNS_VERSION=~1.2.0
-before_install:
-   - echo "{}" > "package.json"
-   - export PATH="$PATH:$(npm bin)"
-install:
-   - npm install "codecov.io" "grunt-laxar@${GRUNT_LAXAR_VERSION}"
-   - cp node_modules/grunt-laxar/widgets/package.json package.json
-   - npm install
-   - bower install "laxar#${LAXAR_VERSION}"
-after_success:
-   - cat lcov.info | codecov
+   - "4"
+   - "6"
 notifications:
    irc:
       channels: "chat.freenode.net#laxarjs"

--- a/ax-markdown-display-widget.js
+++ b/ax-markdown-display-widget.js
@@ -8,8 +8,8 @@ define( [
    'jquery',
    'laxar',
    'laxar-patterns',
-   'marked/lib/marked',
-   'URIjs/src/URI'
+   'marked',
+   'urijs'
 ], function( ng, $, ax, patterns, marked, URI ) {
    'use strict';
 

--- a/ax-markdown-display-widget.js
+++ b/ax-markdown-display-widget.js
@@ -103,16 +103,16 @@ define( [
 
       function loadMarkdownFromUrl( location ) {
          $http.get( location )
-            .success( function( data ) {
+            .then( function( response ) {
+               var data = response.data;
                $scope.model.html =  markdownToHtml( data );
-            } )
-            .error( function( data, status, headers ) {
+            }, function( response ) {
                publishError( 'HTTP_GET', 'i18nFailedLoadingResource', {
                   url: location
                }, {
-                  data: data,
-                  status: status,
-                  headers: headers
+                  data: response.data,
+                  status: response.status,
+                  headers: response.headers
                } );
             } );
       }

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,0 +1,70 @@
+/* eslint-env node */
+
+module.exports = function( config ) {
+   config.set( karmaConfig() );
+};
+
+var karma = require( 'karma' );
+var path = require( 'path' );
+
+var resolve = function(p) { return path.join( __dirname, p ); };
+var polyfillsPath = require.resolve( 'laxar/dist/polyfills' );
+var specsPattern = resolve( 'spec/*.spec.js' );
+var assetsPatterns = [
+   resolve( '*.theme/css/*.css' ),
+   resolve( '*.theme/*.html' )
+];
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+function karmaConfig() {
+
+   var browsers = [
+      'PhantomJS',
+      'Firefox',
+      process.env.TRAVIS ? 'ChromeTravisCi' : 'Chrome'
+   ];
+
+   return {
+      frameworks: [ 'jasmine' ],
+      files: files( specsPattern, [ polyfillsPath ], assetsPatterns ),
+      preprocessors: {
+         [ specsPattern ]: [ 'webpack', 'sourcemap' ]
+      },
+      proxies: {},
+      webpack: webpackConfig(),
+      webpackMiddleware: {
+         noInfo: true,
+         quiet: true
+      },
+
+      reporters: [ 'progress' ],
+      port: 9876,
+      browsers: browsers,
+      customLaunchers: {
+         ChromeTravisCi: {
+            base: 'Chrome',
+            flags: [ '--no-sandbox' ]
+         }
+      },
+      browserNoActivityTimeout: 100000,
+      singleRun: true,
+      autoWatch: false
+   };
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+function webpackConfig() {
+   var config = Object.assign( {}, require('./webpack.config' ) );
+   config.devtool = 'inline-source-map';
+   return config;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+function files( specPath, dependencyPatterns, assetsPatterns ) {
+   return dependencyPatterns
+      .concat([ specPath ])
+      .concat(assetsPatterns.map(function(pattern) { return { pattern: pattern, included: false }; }));
+}

--- a/laxar.config.js
+++ b/laxar.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+   "name": "ax-markdown-display-widget",
+   "version": "3.0.0-pre",
+   "license": "MIT",
+   "repository": {
+      "type": "https",
+      "url": "https://github.com/LaxarJS/ax-markdown-display-widget.git"
+   },
+   "main": "ax-markdown-display-widget.js",
+   "dependencies": {
+      "jquery": "^1.11.x",
+      "marked": "^0.3.x",
+      "urijs": "^1.14.1"
+   }
+}

--- a/package.json
+++ b/package.json
@@ -1,15 +1,49 @@
 {
-   "name": "ax-markdown-display-widget",
-   "version": "3.0.0-pre",
-   "license": "MIT",
-   "repository": {
-      "type": "https",
-      "url": "https://github.com/LaxarJS/ax-markdown-display-widget.git"
-   },
-   "main": "ax-markdown-display-widget.js",
-   "dependencies": {
-      "jquery": "^1.11.x",
-      "marked": "^0.3.x",
-      "urijs": "^1.14.1"
-   }
+  "name": "ax-markdown-display-widget",
+  "version": "3.0.0-pre",
+  "license": "MIT",
+  "repository": {
+    "type": "https",
+    "url": "https://github.com/LaxarJS/ax-markdown-display-widget.git"
+  },
+  "main": "ax-markdown-display-widget.js",
+  "scripts": {
+    "test": "karma start karma.config.js"
+  },
+  "dependencies": {
+    "angular": "^1.5.7",
+    "angular-sanitize": "^1.5.7",
+    "jquery": "^1.11.x",
+    "marked": "^0.3.x",
+    "urijs": "^1.14.1"
+  },
+  "peerDependencies": {
+    "laxar": "^2.0.0-alpha.13",
+    "laxar-uikit": "^2.0.0-alpha.2"
+  },
+  "devDependencies": {
+    "angular-mocks": "^1.5.7",
+    "css-loader": "^0.26.1",
+    "eslint": "^3.0.1",
+    "eslint-config-laxarjs": "^0.3.0",
+    "file-loader": "^0.9.0",
+    "img-loader": "^1.3.1",
+    "jasmine-core": "~2.5.2",
+    "json-loader": "^0.5.4",
+    "karma": "^1.4.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-firefox-launcher": "^1.0.0",
+    "karma-jasmine": "^1.1.0",
+    "karma-phantomjs-launcher": "^1.0.2",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-webpack": "^2.0.1",
+    "laxar-loader": "^0.5.0",
+    "laxar-mocks": "^2.0.0-alpha.1",
+    "source-map-support": "^0.4.10",
+    "style-loader": "^0.13.1",
+    "url-loader": "^0.5.7",
+    "webpack": "^2.2.0-rc.7",
+    "webpack-dev-server": "^2.2.0-rc.0",
+    "webpack-jasmine-html-runner-plugin": "^0.5.0"
+  }
 }

--- a/spec/ax-markdown-display-widget.spec.js
+++ b/spec/ax-markdown-display-widget.spec.js
@@ -14,6 +14,7 @@ define( [
 
    describe( 'An ax-markdown-display-widget', function() {
       var widgetEventBus;
+      var widgetLog;
       var widgetScope;
       var testEventBus;
       var MARKDOWN_DISPLAY_SCROLL = 'markdownDisplayScroll';
@@ -40,19 +41,17 @@ define( [
                $injector.get( '$sce' ).trustAsHtml = function( html ) { return html; };
             } ] );
 
-            ng.mock.inject( [ 'axFlowService', function( axFlowService ) {
-               axFlowService.constructAbsoluteUrl = function( place, optionalParameters ) {
-                  return 'http://localhost:8000/index.html#/widgetBrowser/' +
-                     optionalParameters[ widgetScope.features.markdown.parameter ];
-               };
-            } ] );
+            axMocks.widget.axFlowService.constructAbsoluteUrl = function( place, optionalParameters ) {
+               return 'http://localhost:8000/index.html#/widgetBrowser/' +
+                  optionalParameters[ widgetScope.features.markdown.parameter ];
+            };
          } );
 
          beforeEach( function() {
-            widgetScope = axMocks.widget.$scope;
             widgetEventBus = axMocks.widget.axEventBus;
+            widgetLog = axMocks.widget.axLog;
+            widgetScope = axMocks.widget.$scope;
             testEventBus = axMocks.eventBus;
-            spyOn( ax.log, 'warn' );
          } );
       }
 
@@ -267,7 +266,7 @@ define( [
             } );
 
             testEventBus.flush();
-            expect( ax.log.warn ).toHaveBeenCalled();
+            expect( widgetLog.warn ).toHaveBeenCalled();
          } );
 
          /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -281,13 +280,13 @@ define( [
             } );
 
             testEventBus.flush();
-            expect( ax.log.warn ).toHaveBeenCalled();
+            expect( widgetLog.warn ).toHaveBeenCalled();
          } );
 
          /////////////////////////////////////////////////////////////////////////////////////////////////////
 
          it( 'does not log a warning before the resource is received', function() {
-            expect( ax.log.warn ).not.toHaveBeenCalled();
+            expect( widgetLog.warn ).not.toHaveBeenCalled();
          } );
 
          /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -370,7 +369,7 @@ define( [
             } );
 
             testEventBus.flush();
-            expect( ax.log.warn ).toHaveBeenCalled();
+            expect( widgetLog.warn ).toHaveBeenCalled();
          } );
 
          /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -382,7 +381,7 @@ define( [
             } );
 
             testEventBus.flush();
-            expect( ax.log.warn ).not.toHaveBeenCalled();
+            expect( widgetLog.warn ).not.toHaveBeenCalled();
          } );
 
          /////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/spec/ax-markdown-display-widget.spec.js
+++ b/spec/ax-markdown-display-widget.spec.js
@@ -4,11 +4,12 @@
  * http://laxarjs.org/license
  */
 define( [
-   'json!../widget.json',
+   'json-loader!../widget.json',
    'laxar-mocks',
    'angular-mocks',
+   'angular',
    'laxar'
-], function( descriptor, axMocks, ngMocks, ax ) {
+], function( descriptor, axMocks, ngMocks, ng, ax ) {
    'use strict';
 
    describe( 'An ax-markdown-display-widget', function() {
@@ -17,8 +18,6 @@ define( [
       var testEventBus;
       var MARKDOWN_DISPLAY_SCROLL = 'markdownDisplayScroll';
       var $httpBackend;
-      var $sce;
-      var flowService;
 
       ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -35,19 +34,18 @@ define( [
          beforeEach( axMocks.widget.load );
 
          beforeEach( function() {
-            ngMocks.inject( function( $injector ) {
+            ng.mock.inject( [ '$injector', function( $injector ) {
                $httpBackend = $injector.get( '$httpBackend' );
-               $sce = $injector.get( '$sce' );
-            } );
-            $sce.trustAsHtml =  function( html ) { return html; };
 
-            ngMocks.inject( function( axFlowService ) {
-               flowService = axFlowService;
-            } );
-            flowService.constructAbsoluteUrl = function( place, optionalParameters ) {
-                        return 'http://localhost:8000/index.html#/widgetBrowser/' +
-                               optionalParameters[ widgetScope.features.markdown.parameter ];
-            };
+               $injector.get( '$sce' ).trustAsHtml = function( html ) { return html; };
+            } ] );
+
+            ng.mock.inject( [ 'axFlowService', function( axFlowService ) {
+               axFlowService.constructAbsoluteUrl = function( place, optionalParameters ) {
+                  return 'http://localhost:8000/index.html#/widgetBrowser/' +
+                     optionalParameters[ widgetScope.features.markdown.parameter ];
+               };
+            } ] );
          } );
 
          beforeEach( function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 aixigo AG
+ * Released under the MIT license.
+ * http://laxarjs.org/license
+ */
+/* eslint-env node */
+
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+module.exports = {
+
+   output: {
+      path: path.resolve( './var/build/' ),
+      publicPath: '/var/build/',
+      filename: '[name].bundle.js'
+   },
+
+   module: {
+      rules: [
+         {
+            test: /.spec.js$/,
+            loader: 'laxar-mocks/spec-loader'
+         },
+         {  // load styles, images and fonts with the file-loader
+            // (out-of-bundle in var/build/assets/)
+            test: /\.(gif|jpe?g|png|ttf|woff2?|svg|eot|otf)(\?.*)?$/,
+            loader: 'file-loader',
+            options: {
+               name: 'assets/[name].[ext]'
+            }
+         },
+         {  // ... after optimizing graphics with the image-loader ...
+            test: /\.(gif|jpe?g|png|svg)$/,
+            loader: 'img-loader?progressive=true'
+         },
+         {  // ... and resolving CSS url()s with the css loader
+            // (extract-loader extracts the CSS string from the JS module returned by the css-loader)
+            test: /\.css$/,
+            loader: 'style-loader!css-loader'
+         }
+      ]
+   }
+};


### PR DESCRIPTION
_Note: I created a pull request instead of a plain issue because issues are a pain to do code review on._

Since Laxar 2 is mostly geared towards webpack, which favors NPM over Bower and other types of packages, we are moving all our packages to NPM.

The new `package.json` file should contain:
- [ ] all direct dependencies
- [ ] laxar libraries, the implementation technology and matching adapter as peer (and dev, see below) dependencies
- [ ] a `main` field pointing at the module implementing the controller
- [ ] a `browser` field pointing at a compiled ES5 module of the above (if not already plain ES5)
- [ ] a working test-script

We should also respect NPM/CommonJS semantics. For example "URI.js" is now called "urijs" in the registry and specifies "./src/URI.js" as its main file, so we should import "urijs", not "URIjs/src/URI.js" or anything else.

Most of this is trivial. The test script, however, is a bit more involved. It's mostly about taking what we already have in `grunt-laxar` and replacing it with something built on webpack.
